### PR TITLE
Replace node-open with opn

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chokidar",
     "upath",
     "dialog",
-    "open",
+    "opn",
     "glob"
   ],
   "main": "server.js"

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const url = require('url');
 const dialog = require('dialog');
 const crypto = require('crypto');
 const chokidar = require('chokidar');
-const openUri = require('open');
+const opn = require('opn');
 const config = 'config.json';
 
 if (fs.existsSync(config)) {
@@ -147,7 +147,7 @@ const methods = {
         var fpath = upath.join(working_dir, rpath);
 
         if (fs.existsSync(fpath)){
-            openUri(upath.resolve(fpath), editor);
+            opn(upath.resolve(fpath), { app: editor });
 
             response.setHeader('Location', `dav://${request.headers.host}${uri.pathname}`);
             response.statusCode = 302;


### PR DESCRIPTION
Since [node-open](https://github.com/pwnall/node-open) have been unmaintained for years, I strongly recommend replace it with [opn](https://github.com/sindresorhus/opn).
It can also launch `code` correctly while `node-open` must use full path of vscode binary.