### PR TITLE
Upgrading the name of the opn package to open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,9 @@ typings/
 # next.js build output
 .next
 
+# The npm package-lock.json
+package-lock.json
+
 config.json
 dav
+

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,3 @@ package-lock.json
 
 config.json
 dav
-

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "files": [
     "server.js"
   ],
-  "dependencies": [
-    "chokidar",
-    "upath",
-    "dialog",
-    "opn",
-    "glob"
-  ],
+  "dependencies": {
+    "chokidar": "3.4.3",
+    "dialog": "0.3.1",
+    "glob": "7.1.6",
+    "open": "7.3.0",
+    "upath": "2.0.1"
+  },
   "main": "server.js"
 }

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const url = require('url');
 const dialog = require('dialog');
 const crypto = require('crypto');
 const chokidar = require('chokidar');
-const opn = require('opn');
+const open = require('open');
 const config = 'config.json';
 
 const error = function(m) {
@@ -169,7 +169,7 @@ const methods = {
         var fpath = upath.join(working_dir, rpath);
 
         if (fs.existsSync(fpath)){
-            opn(upath.resolve(fpath), { app: editor });
+            open(upath.resolve(fpath), { app: editor });
 
             response.setHeader('Location', `dav://${request.headers.host}${uri.pathname}`);
             response.statusCode = 302;


### PR DESCRIPTION
Tamperdav does not run out-of-the-box because of an outdated package.json lacking dependency versions.

This PR is a fix for the issue #15 that I opened.